### PR TITLE
実際に利用してみた際からのフィードバックの取り込み

### DIFF
--- a/sample/lib/Choose.js
+++ b/sample/lib/Choose.js
@@ -130,7 +130,7 @@ class ShowStateNodeSet extends StateNodeSet {
 
 			ctx.state.update([{ caller: () => {
 				const parent = this.first.element.parentElement;
-				const afterElement = this.last.element.nextElementSibling;
+				const afterElement = this.last.element.nextSibling;
 				const set = this.nestedNodeSet[0];
 				const page = this.first instanceof StateAsyncComponent ? async () => { await this.first.finished; return set; } : set;
 				switchingPage.afterSwitching = props.initSwitching.value ?? false ? switchingPage.afterSwitching : undefined;
@@ -342,7 +342,7 @@ class WhenStateNodeSet extends StateNodeSet {
 
 		ctx.state.update([{ caller: () => {
 			const parent = this.first.element.parentElement;
-			const afterElement = this.last.element.nextElementSibling;
+			const afterElement = this.last.element.nextSibling;
 			const set = this.nestedNodeSet[0];
 			const page = this.first instanceof StateAsyncComponent ? async () => { await this.first.finished; return set; } : set;
 			const initSwitching = (this.#prevChooseIndex >= 0 ? nestedNodeSet[this.#prevChooseIndex].props.initSwitching.value : undefined) ?? props.initSwitching.value;

--- a/sample/lib/ForEach.js
+++ b/sample/lib/ForEach.js
@@ -237,8 +237,9 @@ class VariableStateNodeSet extends StateNodeSet {
 		}
 		// ノードの削除
 		for (const { switching } of deleteNodeSet) {
-			const node = switching.node;
-			promiseList.push(switching.detach(cancellable).then(() => node.remove()));
+			// ノードは削除されるためリソースを開放しておく
+			switching.node.free();
+			promiseList.push(switching.detach(cancellable));
 		}
 		// 要素が存在しないときはplaceholderを設置
 		if (nodeSetList.length === 0) {

--- a/sample/lib/ForEach.js
+++ b/sample/lib/ForEach.js
@@ -194,7 +194,7 @@ class VariableStateNodeSet extends StateNodeSet {
 			const cancellable = props.cancellable.value;
 			for (const { set, switching } of this.#keyList.values()) {
 				const parent = set.first.element.parentElement;
-				const afterElement = set.last.element.nextElementSibling;
+				const afterElement = set.last.element.nextSibling;
 				switching.afterSwitching = props.initSwitching.value ? switching.afterSwitching : undefined;
 				switching.insertBefore(set, afterElement, parent, cancellable);
 				switching.afterSwitching = props.onAfterSwitching.value;

--- a/src/core.js
+++ b/src/core.js
@@ -300,7 +300,10 @@ class State extends IState {
 	 * 明示的に呼び出し元情報を追加する
 	 * @param { CallerType } caller 呼び出し元の関数
 	 */
-	add(caller) { this.#callerList.add(caller); }
+	add(caller) {
+		this.#ctx.notify(this);
+		this.#callerList.add(caller);
+	}
 
 	/**
 	 * 明示的に呼び出し元情報を削除する
@@ -2475,11 +2478,11 @@ class StateContext {
 	 */
 	notify(state) {
 		if (this.#stack.length > 0) {
-			if (!this.#noreference[0] && (state.onreference instanceof Function)) {
-				// 参照追加に関するイベントの発火
-				state.onreference(state);
-			}
 			this.#stack[this.#stack.length - 1].states.push(state);
+		}
+		if (!this.#noreference[0] && (state.onreference instanceof Function)) {
+			// 参照追加に関するイベントの発火
+			state.onreference(state);
 		}
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -2546,7 +2546,7 @@ class StateContext {
  * コンポーネントのためのコンテキスト
  */
 class Context {
-	/** @type { (typeof window) | import("jsdom").DOMWindow } ウィンドウインターフェース */
+	/** @type { typeof window } ウィンドウインターフェース */
 	#window;
 	/** @type { LifeCycle } コンポーネントに設置されたライフサイクル */
 	#lifecycle = {};
@@ -2571,7 +2571,7 @@ class Context {
 
 	/**
 	 * コンストラクタ
-	 * @param { (typeof window) | import("jsdom").DOMWindow } window ウィンドウインターフェース
+	 * @param { typeof window } window ウィンドウインターフェース
 	 * @param { DomUpdateController | undefined } domUpdateController DOMの更新のためのコントローラ
 	 * @param { StateContext | undefined } stateCtx Suspenseのコンテキスト
 	 * @param { SuspenseContext | undefined } suspenseCtx Suspenseのコンテキスト
@@ -2611,7 +2611,7 @@ class Context {
 
 	/**
 	 * ウィンドウインターフェースの取得
-	 * @returns { (typeof window) | import("jsdom").DOMWindow }
+	 * @returns { typeof window }
 	 */
 	get window() { return this.#window; }
 

--- a/src/core.js
+++ b/src/core.js
@@ -863,14 +863,15 @@ class GenStateNode {
 			while (queueNode.length > 0) {
 				/** @type { (typeof queueNode)[number] } */
 				const { children, element } = queueNode.shift();
+				if (children.length === 0) {
+					continue;
+				}
 				// 子要素の評価と取り出し
 				const childNodes = element?.childNodes ?? [];
-				if (children.length > 0) {
-					// nodeに子が設定されているときはElementノード以外を削除
-					for (const childNode of [...childNodes]) {
-						if (childNode.nodeType !== ctx.window.Node.ELEMENT_NODE) {
-							childNode.remove();
-						}
+				// nodeに子が設定されているときはElementノード以外を削除
+				for (const childNode of [...childNodes]) {
+					if (childNode.nodeType !== ctx.window.Node.ELEMENT_NODE) {
+						childNode.remove();
 					}
 				}
 				const useChildNodes = childNodes.length > 0;
@@ -3127,7 +3128,7 @@ function createWrapperFunction(f, component) {
 function textToStateNodeSet(ctx, text) {
 	const div = ctx.window.document.createElement('div');
 	div.innerHTML = text;
-	return new GenStateNodeSet([...div.childNodes].map(child => html(child)));
+	return new GenStateNodeSet([...div.childNodes].filter(child => child.nodeType === ctx.window.Node.ELEMENT_NODE).map(child => html(child)));
 }
 
 export {

--- a/src/core.js
+++ b/src/core.js
@@ -1635,11 +1635,11 @@ class GenStateDomNode extends GenStateNode {
 			}
 		}
 
-		// 観測の評価(状態の伝播元での副作用として扱う)
+		// 観測の評価
 		if (this.#observableStates) {
 			ctx.state.update2([() => {
 				this.#observeImpl(ctx, this.#observableStates, element);
-			}], ctx.sideEffectLabel);
+			}]);
 		}
 
 		this.#genFlag = true;
@@ -2699,17 +2699,15 @@ class Context {
 			return compResult;
 		}
 		else {
-			// 観測の評価(状態の伝播元での副作用として扱う)
+			// 観測の評価
 			if (observableStates) {
 				const exposeStates = compResult.exposeStates ?? {};
-				this.state.update2([() => {
-					for (const key in observableStates) {
-						const state = observableStates[key];
-						const exposeState = exposeStates[key];
-						// 状態の観測の実施
-						state.observe(exposeState, this.sideEffectLabel);
-					}
-				}], this.sideEffectLabel);
+				for (const key in observableStates) {
+					const state = observableStates[key];
+					const exposeState = exposeStates[key];
+					// 状態の観測の実施
+					state.observe(exposeState);
+				}
 			}
 
 			return compResult.node;

--- a/src/core.js
+++ b/src/core.js
@@ -1537,11 +1537,11 @@ class GenStateDomNode extends GenStateNode {
 
 		// プロパティの設定
 		for (const key in this.#props) {
-			const val = this.#props[key];
-			if (val !== undefined && val !== null && val !== false) {
+			const _val = this.#props[key];
+			if (_val !== undefined && _val !== null && _val !== false) {
 				/** @type { boolean | undefined } 属性として設定を行うかのフラグ */
 				let attrFlag = undefined;
-				const caller = setParam(val, val => {
+				const caller = setParam(_val, val => {
 					// 属性とプロパティで動作に差異のある対象の設定
 					const lowerTag = this.#tag.toLowerCase();
 					// styleはオブジェクト型による設定を許容するため処理を特殊化
@@ -1591,7 +1591,7 @@ class GenStateDomNode extends GenStateNode {
 						if (attrFlag) {
 							// 属性に設定する
 							if (val) {
-								if (val instanceof Function) {
+								if (_val instanceof Function) {
 									// 関数を設定する場合はエラーハンドリングを行うようにする
 									element.setAttribute(key, createWrapperFunctionWithLazy(val, ctx.component));
 									// コンポーネントへ副作用が生じる可能性のある処理が伝播されることを通知する
@@ -1607,7 +1607,7 @@ class GenStateDomNode extends GenStateNode {
 						}
 						else {
 							// プロパティに設定する
-							if (val instanceof Function) {
+							if (_val instanceof Function) {
 								// 関数を設定する場合はエラーハンドリングを行うようにする
 								element[key] = createWrapperFunctionWithLazy(val, ctx.component);
 								// コンポーネントへ副作用が生じる可能性のある処理が伝播されることを通知する

--- a/src/core.js
+++ b/src/core.js
@@ -936,7 +936,7 @@ class GenStateNode {
 						const ret = yield* this.#mountComponent(ctx, child, childNode, lockedLabelSet, waitFlag);
 						node = ret.node;
 						if (child instanceof GenStateAsyncComponent) {
-							// StateAsyncComponentの場合はplaceholderで保管されるため次のchildNodeへ移動しないようにする
+							// StateAsyncComponentの場合はplaceholderで補完されるため次のchildNodeへ移動しないようにする
 							parent.insertBefore(node.element, childNode);
 							continue;
 						}

--- a/src/core.js
+++ b/src/core.js
@@ -254,6 +254,7 @@ class State extends IState {
 	}
 
 	get value() {
+		this.#ctx.onreference(this);
 		// 呼び出し元が有効なら追加する
 		const current = this.#ctx.current;
 		if (current && !this.#callerList.has(current.caller)) {
@@ -301,7 +302,7 @@ class State extends IState {
 	 * @param { CallerType } caller 呼び出し元の関数
 	 */
 	add(caller) {
-		this.#ctx.notify(this);
+		this.#ctx.onreference(this);
 		this.#callerList.add(caller);
 	}
 
@@ -2480,6 +2481,14 @@ class StateContext {
 		if (this.#stack.length > 0) {
 			this.#stack[this.#stack.length - 1].states.push(state);
 		}
+	}
+
+	/**
+	 * 状態変数の参照の通知
+	 * @template T
+	 * @param { State<T> } state 通知対象の状態変数
+	 */
+	onreference(state) {
 		if (!this.#noreference[0] && (state.onreference instanceof Function)) {
 			// 参照追加に関するイベントの発火
 			state.onreference(state);

--- a/src/core.js
+++ b/src/core.js
@@ -3114,6 +3114,17 @@ function createWrapperFunctionWithLazy(f, component) {
 	)
 }
 
+/**
+ * 文字列をStateNodeSetに変換する
+ * @param { Context } ctx 
+ * @param { string } text 
+ */
+function textToStateNodeSet(ctx, text) {
+	const div = ctx.window.document.createElement('div');
+	div.innerHTML = text;
+	return new GenStateNodeSet([...div.childNodes].map(child => html(child)));
+}
+
 export {
 	CommonLabel,
 	IState,
@@ -3139,5 +3150,6 @@ export {
 	normalizeCtxProps,
 	$,
 	t,
-	html
+	html,
+	textToStateNodeSet
 };

--- a/src/core.js
+++ b/src/core.js
@@ -2435,6 +2435,15 @@ class StateContext {
 	}
 
 	/**
+	 * ラベルについてロックされているか調べる
+	 * @param { ICallerLabel } label ラベル
+	 * @returns 
+	 */
+	locked(label) {
+		return this.#lockCaller.has(label);
+	}
+
+	/**
 	 * ロックされた対象のカウントを得る
 	 * @param { ICallerLabel } label カウントを得るラベル
 	 */

--- a/src/core.js
+++ b/src/core.js
@@ -890,7 +890,6 @@ class GenStateNode {
 							// テキストノードもしくはplaceholderであれば挿入して補完する
 							if (useChildNodes) {
 								element.insertBefore(node.element, childNode);
-								++cnt;
 							}
 						}
 						else {
@@ -905,7 +904,7 @@ class GenStateNode {
 					}
 				}
 				// 子要素が多すぎたかの評価
-				if (useChildNodes && cnt < childNodes.length) {
+				if (useChildNodes && cnt + 1 < childNodes.length) {
 					throw new Error('The number of nodes is excessive.');
 				}
 			}


### PR DESCRIPTION
少しの間このライブラリから離れると思うため、忘れないうちに修正内容を取り込んでおく。
## 改修
- 文字列から`StateNodeSet`を生成するための`textToStateNodeSet`の追加
- `onreference`を`State.add`や`State.value`の参照で呼び出されるように変更
- `createWrapperFunctionWithLazy`の除去
- `Context`のフィールド`#window`の型注釈から`import("jsdom").DOMWindow`を除去
- `observe`を副作用として扱わないように変更

## バグ修正
- StateDomNodeでプロパティに設定できないときに異常になるバグの修正
- 子要素が多すぎることについての判定についてのバグの修正
- `StateDomNode`のプロパティに関数要素を設定する際に多重に`createWrapperFunctionWithLazy`を適用するバグの修正
- `ForEach`や`When`で表示する要素が空の場合の場合に正常に動作しないバグの修正
- `observe`により関連付けられたリソースが解放されないバグの修正
- `ForEach`や`When`においてノードを挿入する位置がずれるバグの修正
- テキストノードが複数並んでいる際のハイドレーションに失敗するバグの修正(テキストから取り込んだHTMLにマウントをする際は生じない)
- その他、軽微な誤記等の修正