### PR TITLE
非同期コンポーネントの生成および状態変数の単方向関連付けに関するバグの修正

### DIFF
--- a/sample/lib/Choose.js
+++ b/sample/lib/Choose.js
@@ -108,12 +108,8 @@ class ShowStateNodeSet extends StateNodeSet {
 			this.callerList.push(caller);
 		}
 		// 各種イベントのインスタンスの単方向関連付け
-		ctx.call(() => {
-			switchingPage.afterSwitching = props.onAfterSwitching.value;
-		});
-		ctx.call(() => {
-			switchingPage.beforeSwitching = props.onBeforeSwitching.value;
-		});
+		ctx.state.unidirectional(props.onAfterSwitching, x => switchingPage.afterSwitching = x);
+		ctx.state.unidirectional(props.onBeforeSwitching, x => switchingPage.beforeSwitching = x);
 
 		// 初期表示の設定
 		{
@@ -327,12 +323,8 @@ class WhenStateNodeSet extends StateNodeSet {
 			this.callerList.push(caller);
 		}
 		// 各種イベントのインスタンスの単方向関連付け
-		ctx.call(() => {
-			switchingPage.afterSwitching = props.onAfterSwitching.value;
-		});
-		ctx.call(() => {
-			switchingPage.beforeSwitching = props.onBeforeSwitching.value;
-		});
+		ctx.state.unidirectional(props.onAfterSwitching, x => switchingPage.afterSwitching = x);
+		ctx.state.unidirectional(props.onBeforeSwitching, x => switchingPage.beforeSwitching = x);
 
 		/** @type { GenStateNodeSet } 初期表示の設定 */
 		const genStateNode = this.#chooseNode(ctx, props.target.value, nestedNodeSet, switchingPage);

--- a/sample/lib/ForEach.js
+++ b/sample/lib/ForEach.js
@@ -84,12 +84,8 @@ class VariableStateNodeSet extends StateNodeSet {
 						const switchingPage = new SwitchingPage(suspendGroup);
 						// 各種イベントのインスタンスの単方向関連付け
 						const callerList= [
-							ctx.call(() => {
-								switchingPage.afterSwitching = props.onAfterSwitching.value;
-							}),
-							ctx.call(() => {
-								switchingPage.beforeSwitching = props.onBeforeSwitching.value;
-							})
+							ctx.state.unidirectional(props.onAfterSwitching, x => switchingPage.afterSwitching = x),
+							ctx.state.unidirectional(props.onBeforeSwitching, x => switchingPage.beforeSwitching = x)
 						];
 						keyList.set(key, { set, switching: switchingPage, callerList, index: i });
 						nodeSetList.push(set);
@@ -172,12 +168,8 @@ class VariableStateNodeSet extends StateNodeSet {
 			const switchingPage = new SwitchingPage(suspendGroup);
 			// 各種イベントのインスタンスの単方向関連付け
 			const callerList= [
-				ctx.call(() => {
-					switchingPage.afterSwitching = props.onAfterSwitching.value;
-				}),
-				ctx.call(() => {
-					switchingPage.beforeSwitching = props.onBeforeSwitching.value;
-				})
+				ctx.state.unidirectional(props.onAfterSwitching, x => switchingPage.afterSwitching = x),
+				ctx.state.unidirectional(props.onBeforeSwitching, x => switchingPage.beforeSwitching = x)
 			];
 			// ノードの設定
 			this.#keyList.set(key, { set, switching: switchingPage, callerList, index: this.#keyList.size });

--- a/sample/lib/Suspense.js
+++ b/sample/lib/Suspense.js
@@ -462,17 +462,14 @@ class GenSuspenseStateNodeSet extends GenStateNodeSet {
 		const suspendGroup = new LocalSuspenseContextOnStateNode();
 		const ctx2 = ctx.generateContextForSuspense(new SuspenseContext(suspendGroup));
 		// 各種LocalSuspenseContextOnStateNodeのインスタンスの単方向関連付け
-		ctx2.call(() => {
-			suspendGroup.switchingPage.afterSwitching = this.#props.onAfterSwitching.value;
-		});
-		ctx2.call(() => {
-			suspendGroup.switchingPage.beforeSwitching = this.#props.onBeforeSwitching.value;
-		});
-		ctx2.call({ caller: () => {
-			if (this.#props.fallback.value) {
-				suspendGroup.alternativePage = this.#props.fallback.value.build(ctx2);
+		ctx2.state.unidirectional(this.#props.onAfterSwitching, x => suspendGroup.switchingPage.afterSwitching = x);
+		ctx2.state.unidirectional(this.#props.onBeforeSwitching, x => suspendGroup.switchingPage.beforeSwitching = x);
+		ctx2.state.unidirectional(this.#props.fallback, x => {
+			if (x) {
+				suspendGroup.alternativePage = x.build(ctx2);
 			}
-		}, label: ctx2.sideEffectLabel });
+		}, ctx2.sideEffectLabel);
+
 		this.nestedNodeSet[0].getStateNode(node => suspendGroup.page = node);
 		const set = new StateNodeSet(ctx2, this.nestedNodeSet, sibling);
 		return { set, ctx: ctx2, sibling };


### PR DESCRIPTION
## 非同期コンポーネントがwait指定の際も生成されるバグ
wait指定（`State.write()`呼び出し）で非同期コンポーネントを含むコンポーネントツリーを評価するとき、非同期コンポーネントの生成処理が動いてしまう。


## 状態変数の単方向関連付けで過剰に状態変数をキャプチャするバグ
`StateContext.unidirectional()`で関連付けを行う状態変数以外の状態変数の変更をもキャプチャされる可能性があるコードとなっており、状態変数の複雑な同期を扱う際などに意図しない動作をすることがある。